### PR TITLE
replace custom rightPaddedWithSpaces with a padEnd polyfill

### DIFF
--- a/debify
+++ b/debify
@@ -126,6 +126,26 @@ debFileStream.write("!<arch>" + String.fromCharCode(0x0A)); // Signature
 });
 debFileStream.end();
 
+
+// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
+if (!String.prototype.padEnd) {
+    String.prototype.padEnd = function padEnd(targetLength,padString) {
+        targetLength = targetLength>>0; //floor if number or convert non-number to 0;
+        padString = String((typeof padString !== 'undefined' ? padString : ' '));
+        if (this.length > targetLength) {
+            return String(this);
+        }
+        else {
+            targetLength = targetLength-this.length;
+            if (targetLength > padString.length) {
+                padString += padString.repeat(targetLength/padString.length); //append to original to ensure we are longer than needed
+            }
+            return String(this) + padString.slice(0,targetLength);
+        }
+    };
+}
+
 function rightPaddedWithSpaces(n, string) {
-    return string + Array(n - string.length + 1).join(String.fromCharCode(0x20));
+    return string.padEnd(n, ' ');
 }


### PR DESCRIPTION
In my setup, I run into problems when the code is trying to pad the string from `fileStats.mtime / 1000` up to 12 characters - in my case, that has a decimal dot and three decimals, and the `rightPaddedWithSpaces` function as written will try to instantiate an `Array` with negative size.

Replacing this with a call to the built-in `padEnd()` function solves the problem. I added the polyfill for good measure, in case some user runs this in nodejs < v8.0.0.